### PR TITLE
Publish package on the Github Package Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Logging support for Node
 
 <a name="module_@studyportals/log"></a>
 
+## Publishing the package on the GitHub Package Registry
+1. Ensure you are authenticated to the GitHub Package Registry. [This section](https://help.github.com/en/github/managing-packages-with-github-package-registry/configuring-npm-for-use-with-github-package-registry#authenticating-to-github-package-registry) explains how.
+2. Run `npm publish`
+
 ## @studyportals/log
 
 * [@studyportals/log](#module_@studyportals/log)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "git+https://github.com/studyportals/node-log.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "author": "StudyPortals B.V.",
   "contributors": [
     {


### PR DESCRIPTION
We are looking into publishing on the GitHub Package Registry instead of publicly on NPM's registry for all packages used by https://github.com/studyportals/Portal.